### PR TITLE
client-server/krb5: new test

### DIFF
--- a/testcases/client-server/krb5/client
+++ b/testcases/client-server/krb5/client
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+export KRB5_CONFIG=/run/fedora-networking/krb5.conf
+exec echo aaa | kinit alice

--- a/testcases/client-server/krb5/deps
+++ b/testcases/client-server/krb5/deps
@@ -1,0 +1,3 @@
+krb5-libs
+krb5-server
+krb5-workstation

--- a/testcases/client-server/krb5/server
+++ b/testcases/client-server/krb5/server
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+mkdir -p /run/fedora-networking
+cp -f krb5.conf /run/fedora-networking/
+export KRB5_CONFIG=/run/fedora-networking/krb5.conf
+cp -f kdc.conf /run/fedora-networking/
+cp -f kadm5.acl /run/fedora-networking/
+export KRB5_KDC_PROFILE=/run/fedora-networking/kdc.conf
+cd /run/fedora-networking
+rm -f principal* .k5*
+
+kdb5_util -s -P abc -W create
+kadmin.local -q 'ank -pw aaa alice'
+
+exec /usr/sbin/krb5kdc


### PR DESCRIPTION
New test for MIT Kerberos KDC.

It is not working yet, as the kdb5_util command also creates sockets what confuses the network-testing tool (note: the main krb5 daemon is krb5kdc).
To make this test work, it is necessary to have a mechanism to add a setup script, which will be executed prior the server and/or client.