### PR TITLE
Check whether the event.socket does exist

### DIFF
--- a/network_testing/test_suite.py
+++ b/network_testing/test_suite.py
@@ -216,7 +216,8 @@ class Scenario(object):
                     continue
                 event.socket.status = event.arguments[3].value
             elif event.name == 'shutdown' and event.result == 0:
-                event.socket.shutdown = True
+                if event.socket:
+                    event.socket.shutdown = True
             elif event.name == 'close' and event.result == 0:
                 event.socket.closed = event.time
 


### PR DESCRIPTION
Check whether the event.socket does exist before writing to it.
This should fix the traceback when multithreaded applications are run in server scripts.